### PR TITLE
When I generate a changelog unique constraint is mentioned (changing nothing in db)

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20230120100206_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230120100206_changelog.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="florent (generated)" id="1674208931501-1">
+        <dropUniqueConstraint constraintName="UC_JHI_USERLOGIN_COL" tableName="jhi_user"/>
+    </changeSet>
+    <changeSet author="florent (generated)" id="1674208931501-2">
+        <addUniqueConstraint columnNames="login" constraintName="UC_JHI_USERLOGIN_COL" tableName="jhi_user"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
### Configuration
- liquibase [4.19.0](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/pom.xml#L54-L55)
- database: [postgresql 14.5](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/src/main/docker/postgresql.yml#L5)
- database is created at the startup of the app with liquibase (check this [file](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/src/main/resources/config/liquibase/master.xml) for more details)

### Steps to reproduce
1. Clone this repository
2. Check you are using JDK 11 or 17
3. Start the postgresql database with docker: `docker-compose -f src/main/docker/postgresql.yml up`
4. Run the app with the command `./mvnw`
5. Once started you should get the following log `Application 'mavenPostgre' is running!`
6. You can check the content of the database ([connexion information](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/pom.xml#L818)). If you want to see the unique constraints you can type the following query
```
SELECT *
FROM pg_constraint
WHERE conrelid =
      (SELECT oid
       FROM pg_class
       WHERE relname LIKE 'jhi_user'
       AND contype = 'u');
```
7. Then you can generate a changelog with liquibase with `./mvnw compile liquibase:diff` (I'm using the maven liquibase plugin with this [configuration](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/pom.xml#L814-L826))

### Actual behaviour
The generated changelog looks like [the file in this PR](https://github.com/fleboulch/jhipster-sample-maven-postgre/pull/1/files) (containing 2 changesets)

### Expected behaviour
The generated changelog should be **empty**.
- the 2 changesets should not be here as the constraint is already created [here](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/src/main/resources/config/liquibase/changelog/00000000000000_initial_schema.xml#L23) (even if I change the unique constraint name from `ux_user_login` to `UC_JHI_USERLOGIN_COL` on this file the generated changelog is the same)

### Note
1. Another unique constraint is registered and it never appears in the generated changelog [here](https://github.com/fleboulch/jhipster-sample-maven-postgre/blob/main/src/main/resources/config/liquibase/changelog/00000000000000_initial_schema.xml#L29)
2. The JPA entities are defined [here](https://github.com/fleboulch/jhipster-sample-maven-postgre/tree/main/src/main/java/com/mycompany/myapp/domain)